### PR TITLE
Add a ci check for building w/ component

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,12 +11,12 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     container:
-      image: espressif/idf:release-v5.0
+      image: espressif/idf:release-v5.3
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           submodules: recursive
 
@@ -28,7 +28,38 @@ jobs:
           idf.py build
 
       - name: Archive release
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: elf
+          path: build/*.elf.memfault_log_fmt
+
+  build-with-component:
+    runs-on: ubuntu-latest
+    container:
+      image: espressif/idf:release-v5.3
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Build
+        run: |
+          # set a phony project key
+          echo "CONFIG_MEMFAULT_PROJECT_KEY=\"1234\"" >> sdkconfig.defaults
+          . ${IDF_PATH}/export.sh
+
+          # add the Memfaut component: first get the current submodule version
+          SDK_VERSION=$(grep -oP 'VERSION:\s*\K[^[:space:]]+' third-party/memfault-firmware-sdk/VERSION)
+          # delete the submodule
+          rm -rf third-party/memfault-firmware-sdk
+          # add the dep with the same version
+          idf.py add-dependency "memfault/memfault-firmware-sdk^${SDK_VERSION}"
+
+          MEMFAULT_SDK_COMPONENT=1 idf.py build
+
+      - name: Archive release
+        uses: actions/upload-artifact@v4
+        with:
+          name: elf.component
           path: build/*.elf.memfault_log_fmt

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,13 +15,17 @@ if(DEFINED IDF_VERSION_MAJOR)
   endif()
 endif()
 
-# Look for the Memfault SDK in a subdirectory first, when this app is used
-# standalone (not from within the Memfault SDK)
-get_filename_component(memfault_firmware_sdk_dir third-party/memfault-firmware-sdk ABSOLUTE)
-if(NOT EXISTS ${memfault_firmware_sdk_dir})
-get_filename_component(memfault_firmware_sdk_dir ../../../../ ABSOLUTE)
+# Pull in the Memfault SDK if we're not building as a component, indicated by
+# the absence of the MEMFAULT_SDK_COMPONENT env var.
+if(NOT DEFINED ENV{MEMFAULT_SDK_COMPONENT})
+  # Look for the Memfault SDK in a subdirectory first, when this app is used
+  # standalone (not from within the Memfault SDK)
+  get_filename_component(memfault_firmware_sdk_dir third-party/memfault-firmware-sdk ABSOLUTE)
+  if(NOT EXISTS ${memfault_firmware_sdk_dir})
+    get_filename_component(memfault_firmware_sdk_dir ../../../../ ABSOLUTE)
+  endif()
+  include(${memfault_firmware_sdk_dir}/ports/esp_idf/memfault.cmake)
 endif()
-include(${memfault_firmware_sdk_dir}/ports/esp_idf/memfault.cmake)
 
 # NOTE: This include also applies global compiler options, make sure
 # this happens first before defining other targets!


### PR DESCRIPTION
Changes to support building in 3 configurations:

1. (default) Memfault SDK is git submodule
2. this app is located inside the Memfault SDK, at `examples/esp32/app/memfault`
3. using the Memfault ESP component (requires running `idf.py add-dependency "memfault/memfault-firmware-sdk"` to install the dep)