### PR TITLE
chore: README update

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,12 +5,13 @@ here relative to the ESP-IDF SDK root folder:
 
 - `examples/system/console/advanced/`
 
-```
+```bash
 $ git submodule update --init --recursive
-$ echo '\nCONFIG_MEMFAULT_PROJECT_KEY="YOUR_KEY"' >> sdkconfig.defaults
-$ idf.py set-target esp32
+$ echo 'CONFIG_MEMFAULT_PROJECT_KEY="YOUR_KEY"' >> sdkconfig.defaults
+# by default, 'idf.py build' will target esp32
 $ idf.py build
-$ idf.py flash
+# flash the board and start the serial monitor
+$ idf.py flash monitor
 ```
 
 Get your project key from https://mflt.io/project-key.

--- a/README.md
+++ b/README.md
@@ -5,6 +5,16 @@ here relative to the ESP-IDF SDK root folder:
 
 - `examples/system/console/advanced/`
 
+```
+$ git submodule update --init --recursive
+$ echo '\nCONFIG_MEMFAULT_PROJECT_KEY="YOUR_KEY"' >> sdkconfig.defaults
+$ idf.py set-target esp32
+$ idf.py build
+$ idf.py flash
+```
+
+Get your project key from https://mflt.io/project-key.
+
 ## Configuring for MQTT
 
 This application includes an option to send Memfault data over MQTT. This option requires a few extra pieces to set up.


### PR DESCRIPTION
chore: README update with quickstart instructions

It wasn't obvious to me that I needed to install submodules; adding a
quick note on the commands required to get started with this example.
