### PR TITLE
Fix a build error for esp-idf v6.0

### DIFF
--- a/main/cmd_wifi.c
+++ b/main/cmd_wifi.c
@@ -166,7 +166,8 @@ bool wifi_join(const char *ssid, const char *pass) {
   return false;
 }
 
-static int wifi_disconnect() {
+static int wifi_disconnect(int argc, char **argv) {
+  (void)argc, (void)argv;
   return esp_wifi_disconnect();
 }
 


### PR DESCRIPTION
```plaintext
/esp32-standalone-example/main/cmd_wifi.c:381:54: error: initialization of 'int (*)(int,  char **)' from incompatible pointer type 'int (*)(void)' [-Wincompatible-pointer-types]
  381 |                                              .func = &wifi_disconnect,
      |                                                      ^
```
